### PR TITLE
read xml using utf-8 encoding

### DIFF
--- a/import.py
+++ b/import.py
@@ -14,7 +14,7 @@ def parse_points(file_path):
     Takes in a path to an Apple Health Data
     export file, returns points
     """
-    with open(file_path) as file:
+    with open(file_path, encoding="utf-8") as file:
         tree = et.parse(file)
 
     print("XML loaded.")


### PR DESCRIPTION
Apple Health export is `<?xml version="1.0" encoding="UTF-8"?>`, and it can really contain UTF-8 (MyFitnessPal's meal names, for example). The default encoding for open() in Python3 is platform dependent, so setting explicit encoding is a good thing (tested on Debian 9, python3.5.3)